### PR TITLE
Make url_types seeding customizable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lab.
 .python-version
 templates
 prompts
+customize

--- a/src/ohmyscrapper/__init__.py
+++ b/src/ohmyscrapper/__init__.py
@@ -3,7 +3,7 @@ import argparse
 from ohmyscrapper.modules.classify_urls import classify_urls
 from ohmyscrapper.modules.sniff_url import sniff_url
 from ohmyscrapper.modules.load_txt import load_txt
-from ohmyscrapper.modules.seed import seed
+from ohmyscrapper.modules.seed import seed, export_url_types_to_file
 from ohmyscrapper.modules.scrap_urls import scrap_urls
 from ohmyscrapper.modules.show import (
     show_url,
@@ -40,7 +40,13 @@ def main():
     )
 
     seed_parser = subparsers.add_parser(
-        "seed", help="Seed database. Necessary to classify urls."
+        "seed", help="Seed database with `url_types` to classify the `urls`."
+    )
+    seed_parser.add_argument(
+        "--export",
+        default=False,
+        help="Add all `url_types` from the bank to the `/customize/url_types.yaml` file.",
+        action="store_true",
     )
     untouch_parser = subparsers.add_parser(
         "untouch-all", help="Untouch all urls. That resets classification"
@@ -118,7 +124,10 @@ def main():
         return
 
     if args.command == "seed":
-        seed()
+        if args.export:
+            export_url_types_to_file()
+        else:
+            seed()
         return
 
     if args.command == "untouch-all":

--- a/src/ohmyscrapper/models/urls_manager.py
+++ b/src/ohmyscrapper/models/urls_manager.py
@@ -46,12 +46,10 @@ def create_tables(conn):
     )
 
 
-def seeds():
-    add_urls_valid_prefix("https://%.linkedin.com/posts/%", "linkedin_post")
-    add_urls_valid_prefix("https://lnkd.in/%", "linkedin_redirect")
-    add_urls_valid_prefix("https://%.linkedin.com/jobs/view/%", "linkedin_job")
-    add_urls_valid_prefix("https://%.linkedin.com/feed/%", "linkedin_feed")
-    add_urls_valid_prefix("https://%.linkedin.com/company/%", "linkedin_company")
+def seeds(seeds={}):
+
+    for url_type, url_prefix in seeds.items():
+        add_urls_valid_prefix(url_prefix, url_type)
 
     return True
 

--- a/src/ohmyscrapper/modules/seed.py
+++ b/src/ohmyscrapper/modules/seed.py
@@ -1,7 +1,70 @@
 import ohmyscrapper.models.urls_manager as urls_manager
+import os
+import yaml
 
 
 def seed():
-    urls_manager.seeds()
-    print("🫒 db seeded")
+    seeds = get_url_types_from_file()
+    if len(seeds) == 0:
+        url_types = urls_manager.get_urls_valid_prefix()
+        if len(url_types) == 0:
+            _push_seed_sample_data()
+            seeds = get_url_types_from_file()
+
+    if len(seeds) > 0:
+        urls_manager.seeds(seeds=seeds)
+        print("🫒 db seeded")
     return
+
+
+def _push_seed_sample_data():
+    sample_data = """
+linkedin_post: https://%.linkedin.com/posts/%
+linkedin_redirect: https://lnkd.in/%
+linkedin_job: https://%.linkedin.com/jobs/view/%
+linkedin_feed: https://%.linkedin.com/feed/%
+linkedin_company: https://%.linkedin.com/company/%
+    """.strip()
+
+    with open(_get_url_types_file_path(), "+w") as f:
+        f.write(sample_data)
+
+
+def get_url_types_from_file():
+    if os.path.exists(_get_url_types_file_path()):
+        with open(_get_url_types_file_path(), "r") as f:
+            url_types = yaml.safe_load(f.read())
+            if url_types is None:
+                url_types = {}
+            return url_types
+    else:
+        export_url_types_to_file()
+        return get_url_types_from_file()
+
+
+def export_url_types_to_file():
+    url_types = urls_manager.get_urls_valid_prefix()
+    yaml_url_types = {}
+    for index, url_type in url_types.iterrows():
+        yaml_url_types[url_type["url_type"]] = url_type["url_prefix"]
+
+    # append
+    with open(_get_url_types_file_path(), "+a") as f:
+        yaml.dump(yaml_url_types, f, allow_unicode=True)
+    # read
+    with open(_get_url_types_file_path(), "r") as f:
+        yaml_url_types = yaml.safe_load(f.read())
+    # overwrite preventing repetition
+    with open(_get_url_types_file_path(), "w") as f:
+        yaml.dump(yaml_url_types, f, allow_unicode=True)
+
+
+def _get_url_types_file_path():
+    customize_folder = "customize"
+    url_types_file = "url_types.yaml"
+
+    if not os.path.exists(customize_folder):
+        os.mkdir((customize_folder))
+
+    url_types_file = customize_folder + "/" + url_types_file
+    return url_types_file


### PR DESCRIPTION
The `url_types` seeds now can be loaded via `yaml`.
Use the file `/customize/url_types.yaml` to load your types in this format:
```yaml
my_type_1: http://my_first_url.here
my_type_2: http://my_second_url.here
my_type_3: http://my_third_url.here
```

If you don't have the file, OhMyScrapper will generate it based on the data you already have in your `url_types` table. 

If you don't have the file and the table is empty, OhMyScrapper will generate both based with sample data. 

### Commits
* 167ac54 feat(seed): Make urls_types seed customizable (@bouli)
* 7ed4d40 refactor(sniff_url): Reorganize code to make it customizable (@bouli)